### PR TITLE
ci(#2): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      id: release
+      uses: python-semantic-release/python-semantic-release@v8.0.0
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+      # See https://github.com/actions/runner/issues/1173
+      if: steps.release.outputs.released == 'true'
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+
+    - name: Publish package distributions to GitHub Releases
+      uses: python-semantic-release/upload-to-gh-release@main
+      if: steps.release.outputs.released == 'true'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-   <img src="https://github.com/bossenti/vistafetch/blob/main/docs/img/vistafetch.png"
+   <img src="https://github.com/bossenti/vistafetch/blob/main/docs/img/vistafetch.png?raw=true"
    alt="VistaFetch Logo" title="VistaFetch Logo" width=30%"/>
     <br>VistaFetch
   <br>
@@ -20,7 +20,7 @@
     <img src="https://img.shields.io/badge/typed-mypy-blue" alt="Typed: MyPy">
 </a>
 <a href="https://beta.ruff.rs/docs/" target="_blank">
-    <img src="https://img.shields.io/badge/linting-ruff-yellow" alt="Linting: Ruff">
+    <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Linting: Ruff">
 </a>
 <a href="https://python-poetry.org" target="_blank">
     <img src="https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json" alt="Dependency & Build Management: Poetry">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,14 @@ ignore = [
 "vistafetch/client.py" = ["I001"]
 "vistafetch/model/asset/__init__.py" = ["I001"]
 
+[tool.semantic_release]
+version_variable = [
+    "src_folder/__init__.py:__version__",
+    "pyproject.toml:version"
+]
+branch = "main"
+build_command = "pip install poetry==1.6.1 && poetry build"
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR introduces a workflow for automated semantic releases by using https://github.com/python-semantic-release/python-semantic-release.
Especially important: https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#python-semantic-release-github-action