### PR TITLE
ci: add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "*.*.*"
 
+permissions:
+  contents: write
+  packages: write
+  statuses: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bossenti/vistafetch/security/code-scanning/1](https://github.com/bossenti/vistafetch/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the workflow to function. Based on the steps in the workflow:
- `contents: read` is needed for basic repository access.
- `contents: write` is required for publishing a package and creating a GitHub release.
- `packages: write` is needed for publishing the package to PyPI.
- `statuses: write` may be required for updating commit statuses.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
