### PR TITLE
ci: add permissions to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Continuous Integration
 on:
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     quality-checks:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bossenti/vistafetch/security/code-scanning/3](https://github.com/bossenti/vistafetch/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set the permissions to `contents: read`. This will ensure that the `GITHUB_TOKEN` has the minimal permissions required to execute the workflow.

The `permissions` block will be added at the workflow level to apply to all jobs (`quality-checks` and `unit-tests`) since they share similar requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
